### PR TITLE
🔐 Fix: Remove hardcoded development secrets [#6]

### DIFF
--- a/src/control-plane.ts
+++ b/src/control-plane.ts
@@ -12,6 +12,7 @@ import { InMemoryControlPlaneStore, type ControlPlaneStore } from "./persistence
 import type { EdgeMeshEvent, EdgeMeshPlugin } from "./plugins/types.js";
 import { createTelemetryPlugin, type TelemetryPlugin } from "./plugins/telemetry-plugin.js";
 import { JobTokenManager, NodeJwtManager, NodeTrustManager } from "./security.js";
+import { requireSecretInProduction } from "./utils/secrets.js";
 import { computeRetryDecision } from "./control/retry-policy.js";
 import { startTimeoutReaper } from "./control/timeout-reaper.js";
 
@@ -50,7 +51,7 @@ export function buildControlPlane(
   const tokenManager = new JobTokenManager();
   const trustManager = new NodeTrustManager();
   const nodeJwtManager = options.nodeJwtManager ?? new NodeJwtManager();
-  const adminSecret = process.env.EDGEMESH_ADMIN_SECRET ?? "admin-dev";
+  const adminSecret = requireSecretInProduction("EDGEMESH_ADMIN_SECRET", process.env.EDGEMESH_ADMIN_SECRET, "admin-dev");
 
   const events: EdgeMeshEvent[] = [];
   const ctx = {

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { requireSecretInProduction } from "./utils/secrets.js";
 
 export type JobTokenPayload = {
   jobId: string;
@@ -21,7 +22,11 @@ export class JobTokenManager {
   private usedJtiExp = new Map<string, number>();
 
   constructor(secret?: string) {
-    this.secret = secret ?? process.env.EDGEMESH_JOB_TOKEN_SECRET ?? "dev-secret";
+    this.secret = requireSecretInProduction(
+      "EDGEMESH_JOB_TOKEN_SECRET",
+      secret ?? process.env.EDGEMESH_JOB_TOKEN_SECRET,
+      "dev-secret"
+    );
   }
 
   issue(input: Omit<JobTokenPayload, "jti">) {
@@ -90,7 +95,11 @@ export class NodeJwtManager {
   private readonly ttlMs: number;
 
   constructor(secret?: string, ttlMs?: number) {
-    this.secret = secret ?? process.env.EDGEMESH_NODE_JWT_SECRET ?? "node-jwt-dev";
+    this.secret = requireSecretInProduction(
+      "EDGEMESH_NODE_JWT_SECRET",
+      secret ?? process.env.EDGEMESH_NODE_JWT_SECRET,
+      "node-jwt-dev"
+    );
     this.ttlMs = ttlMs ?? 24 * 60 * 60 * 1000; // 24 h default
   }
 
@@ -140,7 +149,11 @@ export class NodeTrustManager {
   private bootstrapSecret: string;
 
   constructor(secret?: string) {
-    this.bootstrapSecret = secret ?? process.env.EDGEMESH_BOOTSTRAP_SECRET ?? "bootstrap-dev";
+    this.bootstrapSecret = requireSecretInProduction(
+      "EDGEMESH_BOOTSTRAP_SECRET",
+      secret ?? process.env.EDGEMESH_BOOTSTRAP_SECRET,
+      "bootstrap-dev"
+    );
   }
 
   verifyBootstrapToken(token?: string): boolean {

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,0 +1,23 @@
+/**
+ * Validates that a secret is provided in production environments.
+ * Falls back to a development default only in non-production.
+ * 
+ * @param secretName - Name of the secret for error messages
+ * @param envVar - Value from environment variable (may be undefined)
+ * @param devDefault - Development fallback value
+ * @returns The secret value (either from env or dev default)
+ * @throws Error if secret is missing in production
+ */
+export function requireSecretInProduction(
+  secretName: string,
+  envVar: string | undefined,
+  devDefault: string
+): string {
+  if (!envVar && process.env.NODE_ENV === 'production') {
+    throw new Error(
+      `${secretName} must be set in production. ` +
+      `Set the environment variable or NODE_ENV to non-production for development.`
+    );
+  }
+  return envVar ?? devDefault;
+}


### PR DESCRIPTION
## Summary
Implements fix for Issue #6 - removes hardcoded development secrets that could be exploited in production.

## Changes
1. **New utility**: `src/utils/secrets.ts`
   - Added `requireSecretInProduction()` function  
   - Validates secrets are provided in production environments
   - Falls back to dev defaults only when `NODE_ENV !== 'production'`

2. **Updated**: `src/security.ts`
   - `JobTokenManager` constructor uses utility for `EDGEMESH_JOB_TOKEN_SECRET`
   - `NodeJwtManager` constructor uses utility for `EDGEMESH_NODE_JWT_SECRET`
   - `NodeTrustManager` constructor uses utility for `EDGEMESH_BOOTSTRAP_SECRET`

3. **Updated**: `src/control-plane.ts`
   - Added import for `requireSecretInProduction`
   - `adminSecret` initialization uses utility for `EDGEMESH_ADMIN_SECRET`

## Behavior
- **Development**: Works as before with sensible defaults
- **Production**: Throws descriptive error if required secrets are missing
  ```
  Error: EDGEMESH_ADMIN_SECRET must be set in production. 
  Set the environment variable or NODE_ENV to non-production for development.
  ```

## Testing
- Existing tests should pass (dev defaults still work)
- Production deployments will fail-fast if secrets not configured
- Can test locally by setting `NODE_ENV=production` without secrets

## Closes
- Fixes #6

## Next Steps
After merging, update deployment documentation to highlight required environment variables for production.