### PR TITLE
🔄 Fix: Implement exponential backoff in edge node [#5]

### DIFF
--- a/src/edge-node.ts
+++ b/src/edge-node.ts
@@ -7,6 +7,7 @@ const nodeId = process.env.EDGEMESH_NODE_ID ?? `node-${Math.random().toString(36
 const bootstrapToken = process.env.EDGEMESH_BOOTSTRAP_TOKEN ?? "bootstrap-dev";
 const heartbeatMs = Number(process.env.EDGEMESH_HEARTBEAT_MS ?? 3000);
 const pollMs = Number(process.env.EDGEMESH_POLL_MS ?? 1500);
+const MAX_BACKOFF_MS = Number(process.env.EDGEMESH_MAX_BACKOFF_MS ?? 30_000);
 
 let nodeJwt: string | null = null;
 
@@ -156,6 +157,10 @@ async function main() {
     });
   }, heartbeatMs);
 
+  // Exponential backoff state for error handling
+  let backoffMs = pollMs;
+  let consecutiveErrors = 0;
+
   while (true) {
     try {
       const task = await claimTask();
@@ -168,14 +173,29 @@ async function main() {
       const result = await executeTask(task);
       await submitResult(result);
       console.log(`[edge-node:${nodeId}] task completed`, task.taskId, result.ok ? "ok" : "failed");
+      
+      // Reset backoff on successful task execution
+      backoffMs = pollMs;
+      consecutiveErrors = 0;
     } catch (err) {
+      consecutiveErrors++;
+      
       if (String(err).includes("HTTP 401")) {
         console.warn(`[edge-node:${nodeId}] 401 on task loop, re-authenticating`);
         await reAuth().catch((e) => console.error(`[edge-node:${nodeId}] re-auth failed`, e));
       } else {
-        console.error(`[edge-node:${nodeId}] loop error`, err);
+        console.error(`[edge-node:${nodeId}] loop error (attempt ${consecutiveErrors})`, err);
       }
-      await sleep(pollMs);
+      
+      // Exponential backoff with jitter to prevent thundering herd
+      const jitter = Math.random() * 1000; // 0-1000ms jitter
+      const nextBackoff = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+      const sleepTime = Math.min(backoffMs + jitter, MAX_BACKOFF_MS);
+      
+      console.log(`[edge-node:${nodeId}] backing off for ${Math.round(sleepTime)}ms`);
+      await sleep(sleepTime);
+      
+      backoffMs = nextBackoff;
     }
   }
 }


### PR DESCRIPTION
## Summary
Implements exponential backoff with jitter for edge node error handling (Issue #5), preventing thundering herd problems when multiple nodes encounter errors simultaneously.

## Changes
1. **Added constants**:
   - `MAX_BACKOFF_MS` (default: 30s, configurable via `EDGEMESH_MAX_BACKOFF_MS`)

2. **Exponential backoff state tracking**:
   - `backoffMs`: Current backoff duration (starts at `pollMs`)
   - `consecutiveErrors`: Counter for error tracking

3. **Error handling logic**:
   - Doubles backoff on each consecutive error (exponential growth)
   - Adds 0-1000ms random jitter to prevent synchronized retries
   - Caps max backoff at `MAX_BACKOFF_MS` to prevent infinite delays
   - Resets backoff to `pollMs` on successful task execution

4. **Improved observability**:
   - Logs backoff duration: `backing off for Xms`
   - Tracks consecutive error count in log messages

## Before
```typescript
catch (err) {
  console.error(`[edge-node:${nodeId}] loop error`, err);
  await sleep(pollMs); // Fixed 1.5s delay
}
```

## After
```typescript
catch (err) {
  consecutiveErrors++;
  const jitter = Math.random() * 1000;
  const sleepTime = Math.min(backoffMs + jitter, MAX_BACKOFF_MS);
  
  console.log(`backing off for ${Math.round(sleepTime)}ms`);
  await sleep(sleepTime);
  
  backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
}
```

## Backoff Progression Example
| Error # | Backoff (without jitter) | With jitter range |
|---------|--------------------------|-------------------|
| 0       | 1.5s                     | 1.5-2.5s         |
| 1       | 3s                       | 3-4s             |
| 2       | 6s                       | 6-7s             |
| 3       | 12s                      | 12-13s           |
| 4       | 24s                      | 24-25s           |
| 5+      | 30s (max)                | 30-31s           |

## Benefits
- ✅ Prevents control plane overload during outages
- ✅ Distributed jitter reduces synchronized thundering herd 
- ✅ Quick recovery when errors resolve (resets to 1.5s)
- ✅ Bounded worst-case delay (30s cap)
- ✅ Configurable via environment variable

## Testing
- Existing tests should pass
- Manual test: Stop control plane and observe edge node logs
- Should see increasing backoff times with jitter
- Restart control plane and verify quick recovery

## Closes
- Fixes #5